### PR TITLE
fix: skip encoding menu links from dutchie CH-63341

### DIFF
--- a/package.json
+++ b/package.json
@@ -169,6 +169,7 @@
     "lint-fix": "yarn prettier-fix && yarn eslint --fix && yarn stylelint --fix",
     "build-translations": "rm -rf .tmpi18ncache || true && mkdir .tmpi18ncache && yarn run babel --config-file ./babel.i18next-extract.js 'src/**/*.{js,jsx,ts,tsx}' --out-dir '.tmpi18ncache/' && rm -rf .tmpi18ncache && prettier --write 'src/i18n/*.{js,json}'",
     "validate-translations": "node scripts/validate-translations.js",
+    "prepare": "yarn run build",
     "preversion": "make example-deps && git add yarn.lock && git add examples/*/yarn.lock",
     "version": "yarn docs && git add docs && git add yarn.lock examples/*/yarn.lock",
     "postversion": "git push && git push --tags && npm publish"

--- a/src/utils.js
+++ b/src/utils.js
@@ -173,7 +173,6 @@ export const renderText = (text, mentioned_users) => {
 
   let newText = text;
   let markdownLinks = matchMarkdownLinks(newText);
-  console.log(`markdownLinks: ${JSON.stringify(markdownLinks, null, ' ')}`);
   // extract all valid links/emails within text and replace it with proper markup
   linkify.find(newText).forEach(({ type, href, value }) => {
     // check if message is already  markdown
@@ -208,11 +207,7 @@ export const renderText = (text, mentioned_users) => {
       renderers={markDownRenderers}
       escapeHtml={true}
       unwrapDisallowed={true}
-      transformLinkUri={(uri) => {
-        return uri.startsWith('app://')
-          ? uri
-          : RootReactMarkdown.uriTransformer(uri);
-      }}
+      transformLinkUri={(uri) => uri}
     />
   );
 };

--- a/src/utils.js
+++ b/src/utils.js
@@ -207,7 +207,7 @@ export const renderText = (text, mentioned_users) => {
       renderers={markDownRenderers}
       escapeHtml={true}
       unwrapDisallowed={true}
-      transformLinkUri={(uri) => uri}
+      transformLinkUri={null}
     />
   );
 };

--- a/src/utils.js
+++ b/src/utils.js
@@ -207,8 +207,13 @@ export const renderText = (text, mentioned_users) => {
       renderers={markDownRenderers}
       escapeHtml={true}
       unwrapDisallowed={true}
-      transformLinkUri={(uri) =>
-        uri.startsWith('app://') ? uri : RootReactMarkdown.uriTransformer(uri)
+      transformLinkUri={
+        (uri) => {
+          const doNotTransform = uri.startsWith('app://') ||
+            uri.includes('dtche') || uri.includes('dutchie');
+
+          return doNotTransform ? uri : RootReactMarkdown.uriTransformer(uri)
+        }
       }
     />
   );

--- a/src/utils.js
+++ b/src/utils.js
@@ -172,33 +172,33 @@ export const renderText = (text, mentioned_users) => {
   // if (!text) return null;
 
   let newText = text;
-  // let markdownLinks = matchMarkdownLinks(newText);
-  // // extract all valid links/emails within text and replace it with proper markup
-  // linkify.find(newText).forEach(({ type, href, value }) => {
-  //   // check if message is already  markdown
-  //   const noParsingNeeded =
-  //     markdownLinks &&
-  //     markdownLinks.filter((text) => text?.indexOf(href) !== -1);
-  //   if (noParsingNeeded.length > 0) return;
+  let markdownLinks = matchMarkdownLinks(newText);
+  // extract all valid links/emails within text and replace it with proper markup
+  linkify.find(newText).forEach(({ type, href, value }) => {
+    // check if message is already  markdown
+    const noParsingNeeded =
+      markdownLinks &&
+      markdownLinks.filter((text) => text?.indexOf(href) !== -1) || href.includes('dutchie') || href.includes('dtche');
+    if (noParsingNeeded.length > 0) return;
 
-  //   const displayLink =
-  //     type === 'email'
-  //       ? value
-  //       : truncate(value.replace(/(http(s?):\/\/)?(www\.)?/, ''), 20);
-  //   newText = newText.replace(value, `[${displayLink}](${encodeURI(href)})`);
-  // });
+    const displayLink =
+      type === 'email'
+        ? value
+        : truncate(value.replace(/(http(s?):\/\/)?(www\.)?/, ''), 20);
+    newText = newText.replace(value, `[${displayLink}](${encodeURI(href)})`);
+  });
 
-  // if (mentioned_users && mentioned_users.length) {
-  //   for (let i = 0; i < mentioned_users.length; i++) {
-  //     let username = mentioned_users[i].name || mentioned_users[i].id;
-  //     if (username) {
-  //       username = escapeRegExp(username);
-  //     }
-  //     const mkdown = `**@${username}**`;
-  //     const re = new RegExp(`@${username}`, 'g');
-  //     newText = newText.replace(re, mkdown);
-  //   }
-  // }
+  if (mentioned_users && mentioned_users.length) {
+    for (let i = 0; i < mentioned_users.length; i++) {
+      let username = mentioned_users[i].name || mentioned_users[i].id;
+      if (username) {
+        username = escapeRegExp(username);
+      }
+      const mkdown = `**@${username}**`;
+      const re = new RegExp(`@${username}`, 'g');
+      newText = newText.replace(re, mkdown);
+    }
+  }
 
   return (
     <ReactMarkdown

--- a/src/utils.js
+++ b/src/utils.js
@@ -207,14 +207,14 @@ export const renderText = (text, mentioned_users) => {
       renderers={markDownRenderers}
       escapeHtml={true}
       unwrapDisallowed={true}
-      transformLinkUri={
-        (uri) => {
-          const doNotTransform = uri.startsWith('app://') ||
-            uri.includes('dtche') || uri.includes('dutchie');
+      transformLinkUri={(uri) => {
+        const doNotTransform =
+          uri.startsWith('app://') ||
+          uri.includes('dtche') ||
+          uri.includes('dutchie');
 
-          return doNotTransform ? uri : RootReactMarkdown.uriTransformer(uri)
-        }
-      }
+        return doNotTransform ? uri : RootReactMarkdown.uriTransformer(uri);
+      }}
     />
   );
 };

--- a/src/utils.js
+++ b/src/utils.js
@@ -169,7 +169,7 @@ const markDownRenderers = {
 export const renderText = (text, mentioned_users) => {
   // take the @ mentions and turn them into markdown?
   // translate links
-  // if (!text) return null;
+  if (!text) return null;
 
   let newText = text;
   let markdownLinks = matchMarkdownLinks(newText);
@@ -178,14 +178,21 @@ export const renderText = (text, mentioned_users) => {
     // check if message is already  markdown
     const noParsingNeeded =
       markdownLinks &&
-      markdownLinks.filter((text) => text?.indexOf(href) !== -1) ;
+      markdownLinks.filter((text) => text?.indexOf(href) !== -1);
     if (noParsingNeeded.length > 0) return;
 
     const displayLink =
       type === 'email'
         ? value
         : truncate(value.replace(/(http(s?):\/\/)?(www\.)?/, ''), 20);
-    newText = newText.replace(value, `[${displayLink}](${href.includes('dutchie') || href.includes('dtche') ? href : encodeURI(href)})`);
+    newText = newText.replace(
+      value,
+      `[${displayLink}](${
+        href.includes('dutchie') || href.includes('dtche')
+          ? href
+          : encodeURI(href)
+      })`,
+    );
   });
 
   if (mentioned_users && mentioned_users.length) {

--- a/src/utils.js
+++ b/src/utils.js
@@ -203,11 +203,14 @@ export const renderText = (text, mentioned_users) => {
   return (
     <ReactMarkdown
       allowedTypes={allowedMarkups}
+      skipHtml={true}
       source={newText}
       renderers={markDownRenderers}
       escapeHtml={true}
       unwrapDisallowed={true}
-      transformLinkUri={null}
+      transformLinkUri={(uri) =>
+        uri.startsWith('app://') ? uri : RootReactMarkdown.uriTransformer(uri)
+      }
     />
   );
 };

--- a/src/utils.js
+++ b/src/utils.js
@@ -173,6 +173,7 @@ export const renderText = (text, mentioned_users) => {
 
   let newText = text;
   let markdownLinks = matchMarkdownLinks(newText);
+  console.log(`markdownLinks: ${JSON.stringify(markdownLinks, null, ' ')}`);
   // extract all valid links/emails within text and replace it with proper markup
   linkify.find(newText).forEach(({ type, href, value }) => {
     // check if message is already  markdown
@@ -208,12 +209,9 @@ export const renderText = (text, mentioned_users) => {
       escapeHtml={true}
       unwrapDisallowed={true}
       transformLinkUri={(uri) => {
-        const doNotTransform =
-          uri.startsWith('app://') ||
-          uri.includes('dtche') ||
-          uri.includes('dutchie');
-
-        return doNotTransform ? uri : RootReactMarkdown.uriTransformer(uri);
+        return uri.startsWith('app://')
+          ? uri
+          : RootReactMarkdown.uriTransformer(uri);
       }}
     />
   );

--- a/src/utils.js
+++ b/src/utils.js
@@ -169,41 +169,40 @@ const markDownRenderers = {
 export const renderText = (text, mentioned_users) => {
   // take the @ mentions and turn them into markdown?
   // translate links
-  if (!text) return null;
+  // if (!text) return null;
 
   let newText = text;
-  let markdownLinks = matchMarkdownLinks(newText);
-  // extract all valid links/emails within text and replace it with proper markup
-  linkify.find(newText).forEach(({ type, href, value }) => {
-    // check if message is already  markdown
-    const noParsingNeeded =
-      markdownLinks &&
-      markdownLinks.filter((text) => text?.indexOf(href) !== -1);
-    if (noParsingNeeded.length > 0) return;
+  // let markdownLinks = matchMarkdownLinks(newText);
+  // // extract all valid links/emails within text and replace it with proper markup
+  // linkify.find(newText).forEach(({ type, href, value }) => {
+  //   // check if message is already  markdown
+  //   const noParsingNeeded =
+  //     markdownLinks &&
+  //     markdownLinks.filter((text) => text?.indexOf(href) !== -1);
+  //   if (noParsingNeeded.length > 0) return;
 
-    const displayLink =
-      type === 'email'
-        ? value
-        : truncate(value.replace(/(http(s?):\/\/)?(www\.)?/, ''), 20);
-    newText = newText.replace(value, `[${displayLink}](${encodeURI(href)})`);
-  });
+  //   const displayLink =
+  //     type === 'email'
+  //       ? value
+  //       : truncate(value.replace(/(http(s?):\/\/)?(www\.)?/, ''), 20);
+  //   newText = newText.replace(value, `[${displayLink}](${encodeURI(href)})`);
+  // });
 
-  if (mentioned_users && mentioned_users.length) {
-    for (let i = 0; i < mentioned_users.length; i++) {
-      let username = mentioned_users[i].name || mentioned_users[i].id;
-      if (username) {
-        username = escapeRegExp(username);
-      }
-      const mkdown = `**@${username}**`;
-      const re = new RegExp(`@${username}`, 'g');
-      newText = newText.replace(re, mkdown);
-    }
-  }
+  // if (mentioned_users && mentioned_users.length) {
+  //   for (let i = 0; i < mentioned_users.length; i++) {
+  //     let username = mentioned_users[i].name || mentioned_users[i].id;
+  //     if (username) {
+  //       username = escapeRegExp(username);
+  //     }
+  //     const mkdown = `**@${username}**`;
+  //     const re = new RegExp(`@${username}`, 'g');
+  //     newText = newText.replace(re, mkdown);
+  //   }
+  // }
 
   return (
     <ReactMarkdown
       allowedTypes={allowedMarkups}
-      skipHtml={true}
       source={newText}
       renderers={markDownRenderers}
       escapeHtml={true}

--- a/src/utils.js
+++ b/src/utils.js
@@ -178,14 +178,14 @@ export const renderText = (text, mentioned_users) => {
     // check if message is already  markdown
     const noParsingNeeded =
       markdownLinks &&
-      markdownLinks.filter((text) => text?.indexOf(href) !== -1) || href.includes('dutchie') || href.includes('dtche');
+      markdownLinks.filter((text) => text?.indexOf(href) !== -1) ;
     if (noParsingNeeded.length > 0) return;
 
     const displayLink =
       type === 'email'
         ? value
         : truncate(value.replace(/(http(s?):\/\/)?(www\.)?/, ''), 20);
-    newText = newText.replace(value, `[${displayLink}](${encodeURI(href)})`);
+    newText = newText.replace(value, `[${displayLink}](${href.includes('dutchie') || href.includes('dtche') ? href : encodeURI(href)})`);
   });
 
   if (mentioned_users && mentioned_users.length) {


### PR DESCRIPTION
# Problem
Fixes issue with putting embedded menu links into messages where they would get double encoded causing deep links to menu items to break and fall back to the dispensary's home menu.

# Testing Instructions
* For a dispensary that has messaging enabled, start a new message conversation
* Send a message with a link like `https://www.serenity-cannabis.com/menu?dtche%5Bproduct%5D=tweed-penelope-1g`
* Click on the link and ensure it takes you to the actual menu item.

# Clubhouse Story
[ch63341](https://app.clubhouse.io/dutchie/story/63341/menu-deeplinks-break-when-sending-through-customer-messaging-due-to-being-replaced-with-the-html-entity-25)